### PR TITLE
Add script to run Docker Desktop on Ubuntu 24.04

### DIFF
--- a/run-docker-desktop-on-Ubuntu24-04.sh
+++ b/run-docker-desktop-on-Ubuntu24-04.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env zsh
+#
+sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+systemctl --user restart docker-desktop


### PR DESCRIPTION
This script solves the issue of docker desktop stopped working after upgrading Ubuntu from 23.10 to 24.04.